### PR TITLE
update gemfile.lock after removing vcr gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,8 +283,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (0.13.0)
-    vcr (6.3.1)
-      base64
     warden (1.2.9)
       rack (>= 2.0.9)
     warden-jwt_auth (0.10.0)
@@ -331,7 +329,6 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
   tzinfo-data
-  vcr
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
## Type of Change
- [ ] New Feature
- [x] Debugging
- [ ] Refactor

## Describe Changes Made
- auto deploy to heroku failed due to "Heroku detected that you’ve removed the vcr gem from your Gemfile, but the corresponding change has not been reflected in your Gemfile.lock due to the “frozen” setting in bundler, which prevents any changes to the lockfile during deployment."

## PR Checklist
- [X] Added Reviewer
- [ ] Followed TDD, And Test are Passing
