### PR TITLE
move rswag to production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem "rack-cors"
 gem "devise"
 gem "devise-jwt"
 gem "stripe"
+gem 'rswag'
+gem 'rswag-api'
+gem 'rswag-ui'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -53,9 +56,6 @@ group :development, :test do
   gem "faker"
   gem "simplecov"
   gem 'shoulda-matchers'
-  gem 'rswag'
-  gem 'rswag-api'
-  gem 'rswag-ui'
 end
 
 group :test do


### PR DESCRIPTION
## Type of Change
- [X] Debugging

## Describe Changes Made
production error, heroku logs led to a `uninitialized constant Rswag (NameError)` so updating the gemfile to add rswag lines to production block

## PR Checklist
- [X] Added Reviewer
- [X] Followed TDD, And Test are Passing
